### PR TITLE
fix(windows-1809): add wf build publish

### DIFF
--- a/.github/workflows/build-windows-image.yml
+++ b/.github/workflows/build-windows-image.yml
@@ -46,5 +46,5 @@ jobs:
           dockerfile: docker/Dockerfile.windows.1809
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
-          pushImage: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        #   pushImage: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
           platform: windows/amd64

--- a/.github/workflows/build-windows-image.yml
+++ b/.github/workflows/build-windows-image.yml
@@ -1,0 +1,42 @@
+name: Build and Publish Windows Image
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "docker/Dockerfile.windows.1809"
+      - ".github/workflows/build-windows-image.yml"
+  pull_request:
+    paths:
+      - "docker/Dockerfile.windows.1809"
+      - ".github/workflows/build-windows-image.yml"
+jobs:
+  build-and-push:
+    name: Push image
+    runs-on: windows-2019
+    steps:
+      - name: Checkout
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+      - name: Get DockerHub credentials
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          common_secrets: |
+            DOCKERHUB_USERNAME=dockerhub-platform-productivity:username
+            DOCKERHUB_TOKEN=dockerhub-platform-productivity:token
+      - name: Log in to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+      - name: Generate tag
+        id: generate_tag
+        run: |
+          echo "tag=$(date +%F)-windows-amd64" >> $GITHUB_OUTPUT
+      - name: Build and optionally push
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          tags: grafana/drone-git:${{ steps.generate_tag.outputs.tag }}
+          platforms: windows/amd64

--- a/.github/workflows/build-windows-image.yml
+++ b/.github/workflows/build-windows-image.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build-and-push:
-    name: Push image
+    name: Build and optionally push image
     runs-on: windows-2019
     steps:
       - name: Checkout

--- a/.github/workflows/build-windows-image.yml
+++ b/.github/workflows/build-windows-image.yml
@@ -28,11 +28,6 @@ jobs:
           common_secrets: |
             DOCKERHUB_USERNAME=dockerhub-platform-productivity:username
             DOCKERHUB_TOKEN=dockerhub-platform-productivity:token
-    #   - name: Log in to Docker Hub
-    #     uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-    #     with:
-    #       username: ${{ env.DOCKERHUB_USERNAME }}
-    #       password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Generate tag
         id: generate_tag
         run: |
@@ -46,5 +41,5 @@ jobs:
           dockerfile: docker/Dockerfile.windows.1809
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
-        #   pushImage: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          pushImage: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
           platform: windows/amd64

--- a/.github/workflows/build-windows-image.yml
+++ b/.github/workflows/build-windows-image.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Generate tag
         id: generate_tag
         run: |
-          echo "tag=$(date +%F)-windows-amd64" >> $GITHUB_OUTPUT
+          echo "tag=$(date +%F)-windows-amd64" >> $ENV:GITHUB_OUTPUT
       - name: Build and optionally push
         uses: mr-smithers-excellent/docker-build-push@59523c638baec979a74fea99caa9e29d97e5963c # v6.4.0
         with:

--- a/.github/workflows/build-windows-image.yml
+++ b/.github/workflows/build-windows-image.yml
@@ -10,6 +10,11 @@ on:
     paths:
       - "docker/Dockerfile.windows.1809"
       - ".github/workflows/build-windows-image.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build-and-push:
     name: Push image

--- a/.github/workflows/build-windows-image.yml
+++ b/.github/workflows/build-windows-image.yml
@@ -17,26 +17,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
       - name: Get DockerHub credentials
         uses: grafana/shared-workflows/actions/get-vault-secrets@main
         with:
           common_secrets: |
             DOCKERHUB_USERNAME=dockerhub-platform-productivity:username
             DOCKERHUB_TOKEN=dockerhub-platform-productivity:token
-      - name: Log in to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
-          password: ${{ env.DOCKERHUB_TOKEN }}
+    #   - name: Log in to Docker Hub
+    #     uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+    #     with:
+    #       username: ${{ env.DOCKERHUB_USERNAME }}
+    #       password: ${{ env.DOCKERHUB_TOKEN }}
       - name: Generate tag
         id: generate_tag
         run: |
           echo "tag=$(date +%F)-windows-amd64" >> $GITHUB_OUTPUT
       - name: Build and optionally push
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        uses: mr-smithers-excellent/docker-build-push@59523c638baec979a74fea99caa9e29d97e5963c # v6.4.0
         with:
-          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-          tags: grafana/drone-git:${{ steps.generate_tag.outputs.tag }}
-          platforms: windows/amd64
+          image: grafana/drone-git
+          tags: ${{ steps.generate_tag.outputs.tag }}
+          registry: docker.io
+          dockerfile: docker/Dockerfile.windows.1809
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+          pushImage: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          platform: windows/amd64


### PR DESCRIPTION
This sets up a workflow to build and publish the Windows 1809 image.
Image publish only occurs on pushes to master branch.