### PR TITLE
chore(win): update version of git we pull

### DIFF
--- a/docker/Dockerfile.windows.1809
+++ b/docker/Dockerfile.windows.1809
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/windows/servercore:1809 AS git
 SHELL ["powershell.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.31.1.windows.1/MinGit-2.31.1-64-bit.zip -OutFile git.zip; `
+    Invoke-WebRequest -UseBasicParsing https://github.com/git-for-windows/git/releases/download/v2.47.0.windows.2/MinGit-2.47.0.2-64-bit.zip -OutFile git.zip; `
     Expand-Archive git.zip -DestinationPath C:\git;
 RUN C:\git\cmd\git.exe config --system core.autocrlf false
 


### PR DESCRIPTION
We're having some issues with git on certain drone build types. This is an attempt at fixing those issues by upgrading the version of git we're using.

