### PR TITLE
fix(clone-tag-pwsh): refactor script to avoid empty flag

### DIFF
--- a/.github/workflows/build-windows-image.yml
+++ b/.github/workflows/build-windows-image.yml
@@ -6,10 +6,12 @@ on:
     paths:
       - "docker/Dockerfile.windows.1809"
       - ".github/workflows/build-windows-image.yml"
+      - "windows/**"
   pull_request:
     paths:
       - "docker/Dockerfile.windows.1809"
       - ".github/workflows/build-windows-image.yml"
+      - "windows/**"
 
 permissions:
   contents: read

--- a/windows/clone-tag.ps1
+++ b/windows/clone-tag.ps1
@@ -1,13 +1,20 @@
-
-Set-Variable -Name "FLAGS" -Value ""
 if ($Env:PLUGIN_DEPTH) {
-    Set-Variable -Name "FLAGS" -Value "--depth=$Env:PLUGIN_DEPTH" 
+    $flags = "--depth=$Env:PLUGIN_DEPTH"
+}
+else {
+    $flags = ""
 }
 
-if (!(Test-Path .git)) {
-	git init
-	git remote add origin $Env:DRONE_REMOTE_URL
+if (!(Test-Path -Path .git)) {
+    git init
+    git remote add origin $Env:DRONE_REMOTE_URL
 }
 
-git fetch $FLAGS origin "+refs/tags/${Env:DRONE_TAG}:"
+if ($flags) {
+    git fetch $flags origin "+refs/tags/${Env:DRONE_TAG}:"
+}
+else {
+    git fetch origin "+refs/tags/${Env:DRONE_TAG}:"
+}
+
 git checkout -qf FETCH_HEAD


### PR DESCRIPTION
This refactors this script with various powershell best-practices. Additionally, it seems that `git fetch` does not like having the empty string `$FLAGS`. So let's have 2 explicit branches of execution.

