### PR TITLE
ci: stop using windows-2019 runners

### DIFF
--- a/.github/workflows/build-windows-image.yml
+++ b/.github/workflows/build-windows-image.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build-and-push:
     name: Build and optionally push image
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1


### PR DESCRIPTION
The windows-2019 runners are deprecated as of 2025-06-01 and will be fully unsupported by 2025-06-30. There will be multiple brown-outs over the course of this month which might affect builds and releases unless we remove those runners.

See https://github.com/actions/runner-images/issues/12045 for details.

